### PR TITLE
Fix misspelling in comment

### DIFF
--- a/upower/upower.go
+++ b/upower/upower.go
@@ -38,7 +38,7 @@ func GetBrightness(o DbusObject) (int32, error) {
 }
 
 func SetBrightness(o DbusObject, value int32) error {
-	return o.Call(CALL_SET_BRIGHTNESS, 0, value).Store() // Hack so we don't need to listen on call.Dbus and to get call.Err returned instead of having it as a memeber
+	return o.Call(CALL_SET_BRIGHTNESS, 0, value).Store() // Hack so we don't need to listen on call.Dbus and to get call.Err returned instead of having it as a member
 }
 
 func SignalListen(conn DbusConnection, o DbusObject, ch chan<- *dbus.Signal) {


### PR DESCRIPTION
Tackle this from the Go Report Card:
```
Misspell Finds commonly misspelled English words
skbl/upower/upower.go
                Line 41: warning: "memeber" is a misspelling of "member" (misspell)
```